### PR TITLE
Add NOT IN tests for cluster filter exclusion

### DIFF
--- a/tests/integration/lib.sh
+++ b/tests/integration/lib.sh
@@ -94,6 +94,25 @@ assert_contains() {
     fi
 }
 
+# Assert query output does NOT contain a value
+assert_not_contains() {
+    local desc="$1"
+    local context="$2"
+    local query="$3"
+    local unexpected="$4"
+
+    local result
+    result=$(run_query "$context" "$query")
+
+    if echo "$result" | grep -q "$unexpected"; then
+        echo -e "${RED}✗${NC} $desc (unexpectedly contained: $unexpected)"
+        FAIL=$((FAIL + 1))
+    else
+        echo -e "${GREEN}✓${NC} $desc"
+        PASS=$((PASS + 1))
+    fi
+}
+
 # Assert table output contains expected value
 assert_table_contains() {
     local desc="$1"

--- a/tests/integration/tests/02-multi-cluster.sh
+++ b/tests/integration/tests/02-multi-cluster.sh
@@ -46,4 +46,14 @@ assert_contains "IN list returns cluster 2 pods" "k3d-k8sql-test-1" \
 assert_contains "_cluster column in output" "k3d-k8sql-test-1" \
     "SELECT _cluster, name FROM pods WHERE namespace = 'default' LIMIT 1" "k3d-k8sql-test-1"
 
+# NOT IN tests - verify exclusion works correctly
+# NOT IN should query all clusters EXCEPT the excluded ones
+assert_contains "NOT IN returns cluster 1" "k3d-k8sql-test-1" \
+    "SELECT DISTINCT _cluster FROM pods WHERE _cluster NOT IN ('k3d-k8sql-test-2') AND namespace = 'default'" \
+    "k3d-k8sql-test-1"
+
+assert_not_contains "NOT IN excludes cluster 2" "k3d-k8sql-test-1" \
+    "SELECT DISTINCT _cluster FROM pods WHERE _cluster NOT IN ('k3d-k8sql-test-2') AND namespace = 'default'" \
+    "k3d-k8sql-test-2"
+
 print_summary


### PR DESCRIPTION
## Summary
- Add `assert_not_contains` helper to test library
- Add tests to verify `_cluster NOT IN (...)` correctly excludes clusters

## Test plan
- CI will verify whether NOT IN works correctly or if it has the same DataFusion rewrite issue as IN lists

This is a verification test to check if `NOT IN` might be rewritten to `!= AND !=` chains that we don't currently handle.