### PR TITLE
Add PostgreSQL client compatibility and unify context behavior

### DIFF
--- a/src/datafusion_integration/context.rs
+++ b/src/datafusion_integration/context.rs
@@ -35,16 +35,11 @@ impl K8sSessionContext {
 
     /// Create and configure a SessionContext with all K8s tables registered
     async fn create_session_context(pool: &Arc<K8sClientPool>) -> anyhow::Result<SessionContext> {
-        // Get the current Kubernetes context name for the catalog
-        let cluster_name = pool
-            .current_context()
-            .await
-            .unwrap_or_else(|_| "k8s".to_string());
-
-        // Enable information_schema and use cluster name as catalog
+        // Use "postgres" catalog and "public" schema for PostgreSQL client compatibility
+        // The _cluster column handles multi-cluster differentiation
         let config = SessionConfig::new()
             .with_information_schema(true)
-            .with_default_catalog_and_schema(&cluster_name, "default");
+            .with_default_catalog_and_schema("postgres", "public");
         let mut ctx = SessionContext::new_with_config(config);
 
         // Register JSON functions for querying spec/status fields

--- a/src/datafusion_integration/mod.rs
+++ b/src/datafusion_integration/mod.rs
@@ -14,4 +14,4 @@ mod preprocess;
 mod provider;
 
 pub use context::K8sSessionContext;
-pub use hooks::{ShowDatabasesHook, ShowTablesHook};
+pub use hooks::{SetConfigHook, ShowDatabasesHook, ShowTablesHook};


### PR DESCRIPTION
## Summary

- **DBeaver/PostgreSQL client compatibility**: Add `SetConfigHook` to handle SET commands and register `pg_catalog` system tables for client introspection
- **Context behavior unification**: Add `K8sClientPool::with_context_spec()` for consistent multi-context handling across all modes
- **Daemon --context support**: Daemon mode now supports `--context` with globs and comma-separated lists
- **Predictable context behavior**: Batch/daemon modes ignore saved REPL config; only `USE` command persists in REPL

## Test plan

- [ ] Build with `cargo build --release`
- [ ] Test DBeaver connection: `k8sql daemon --port 15432` then connect via DBeaver
- [ ] Test batch mode context isolation (run without `-c` with fake saved config)
- [ ] Test daemon with glob: `k8sql -c '*' daemon --port 15432`
- [ ] Test REPL --context temporary override
- [ ] Run integration tests: `tests/integration/tests/07-repl-mode.sh`, `08-daemon-mode.sh`, `09-batch-multi-context.sh`