### PR TITLE
Remove unused --namespace CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ k8sql -q "SELECT * FROM deployments" -o json
 ```
 -q, --query <SQL>       Execute a SQL query directly
 -c, --context <CTX>     Kubernetes context(s): name, comma-separated, or glob pattern
--n, --namespace <NS>    Default namespace (default: "default")
 -o, --output <FMT>      Output format: table, json, csv, yaml (default: table)
 -f, --file <PATH>       Execute queries from a file
     --no-headers        Omit column headers in output

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -20,10 +20,6 @@ pub struct Args {
     #[arg(short, long, value_name = "CONTEXT")]
     pub context: Option<String>,
 
-    /// Default namespace
-    #[arg(short, long, default_value = "default")]
-    pub namespace: String,
-
     /// Output format
     #[arg(short, long, value_enum, default_value = "table")]
     pub output: OutputFormat,


### PR DESCRIPTION
## Summary

Removes the `--namespace` CLI argument that was defined but never actually used in the codebase.

## Problem

The `-n, --namespace` argument appeared in `--help` and documentation, but was completely unused:
- Not passed to any functions
- Not referenced in batch or interactive modes
- Never used in query execution

This created confusion about how namespace filtering works.

## Solution

**Removed:**
- `namespace` field from `Args` struct (src/cli/args.rs)
- `-n, --namespace` from README.md CLI options

**Namespace filtering still works correctly** through SQL WHERE clauses:
```sql
SELECT * FROM pods WHERE namespace = 'kube-system'
SELECT * FROM pods WHERE namespace IN ('default', 'kube-system')
```

The query optimizer continues to push these filters to the Kubernetes API for efficient execution.

## Verification

- ✅ All 119 tests passing
- ✅ `cargo fmt` clean
- ✅ `cargo clippy` clean
- ✅ Build successful
- ✅ `--help` output correct (no namespace option)

## Files Modified

- `src/cli/args.rs` - Removed unused namespace field
- `README.md` - Removed CLI option from documentation