### PR TITLE
Simplify NULL semantics and timestamp helpers

### DIFF
--- a/src/kubernetes/cache.rs
+++ b/src/kubernetes/cache.rs
@@ -537,10 +537,7 @@ mod tests {
             aliases: vec![name.to_lowercase()],
             is_core: false,
             custom_fields: None,
-            created_at: SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
+            created_at: current_timestamp(),
         }
     }
 


### PR DESCRIPTION
## Summary

- Extract `pushdown_for_equality_op()` helper in `provider.rs` to replace 3 repeated if-else blocks handling `!=` operator pushdown semantics
- Use existing `current_timestamp()` helper in `cache.rs` test instead of inline `SystemTime` calculation

## Details

The NULL semantics helper centralizes the logic for determining filter pushdown level based on equality operators:
- `=` returns `Exact` (K8s API handles it completely)
- `!=` returns `Inexact` (K8s pre-filters, DataFusion re-applies for SQL NULL compliance)

This difference exists because K8s treats `key!=value` as "not equal OR missing", while SQL treats `NULL != 'value'` as NULL (excluded from results).

## Test plan

- [x] `cargo test` - all 161 tests pass
- [x] `cargo clippy` - no warnings