### PR TITLE
Add support for PodMetrics and NodeMetrics tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,6 +2005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "go-parse-duration"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,6 +2482,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-metrics"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcd5147ecf729236adaca0ebe19ecd10265592d02541d0b4b467c78ddf1e239d"
+dependencies = [
+ "go-parse-duration",
+ "k8s-openapi",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2504,6 +2522,7 @@ dependencies = [
  "dirs",
  "futures",
  "indicatif",
+ "k8s-metrics",
  "k8s-openapi",
  "kube",
  "lazy-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ datafusion-functions-json = "0.51"
 # Kubernetes client
 kube = { version = "2", features = ["runtime", "client", "derive", "rustls-tls", "http-proxy"] }
 k8s-openapi = { version = "0.26", features = ["v1_32"] }
+k8s-metrics = "0.26"
 
 # TLS provider for rustls (aws-lc-rs preferred for performance)
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std", "tls12"] }

--- a/tests/integration/tests/22-metrics-api.sh
+++ b/tests/integration/tests/22-metrics-api.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Metrics API tests for k8sql (requires metrics-server)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib.sh"
+
+echo "=== Metrics API Tests ==="
+
+# Check if metrics-server is available
+# The metrics.k8s.io API group may not be available in minimal clusters (k3d, kind without metrics-server)
+check_metrics_available() {
+    local context="$1"
+    # Try to access the metrics API - will fail if metrics-server not installed
+    kubectl --context "$context" get --raw /apis/metrics.k8s.io/v1beta1 &>/dev/null
+}
+
+if ! check_metrics_available "k3d-k8sql-test-1"; then
+    echo "SKIP: metrics-server not available in test cluster (this is expected for k3d/kind)"
+    echo "      To run metrics tests, install metrics-server or use a cluster with it (EKS, GKE, etc.)"
+    print_summary
+    exit 0
+fi
+
+echo "metrics-server detected, running metrics tests..."
+
+# SHOW TABLES should include podmetrics and nodemetrics
+assert_table_contains "SHOW TABLES includes podmetrics" "k3d-k8sql-test-1" \
+    "SHOW TABLES" "podmetrics"
+
+assert_table_contains "SHOW TABLES includes nodemetrics" "k3d-k8sql-test-1" \
+    "SHOW TABLES" "nodemetrics"
+
+# Basic podmetrics query - should have at least one pod with metrics
+assert_min_row_count "SELECT from podmetrics returns results" "k3d-k8sql-test-1" \
+    "SELECT name, namespace FROM podmetrics" 1
+
+# Podmetrics specific columns (timestamp, window, containers)
+assert_success "Podmetrics has timestamp column" "k3d-k8sql-test-1" \
+    "SELECT name, timestamp FROM podmetrics LIMIT 1"
+
+assert_success "Podmetrics has window column" "k3d-k8sql-test-1" \
+    "SELECT name, window FROM podmetrics LIMIT 1"
+
+assert_success "Podmetrics has containers column" "k3d-k8sql-test-1" \
+    "SELECT name, containers FROM podmetrics LIMIT 1"
+
+# All podmetrics columns together
+assert_success "Podmetrics all special columns" "k3d-k8sql-test-1" \
+    "SELECT name, namespace, timestamp, window, containers FROM podmetrics LIMIT 3"
+
+# Nodemetrics query - should have exactly 1 node (k3d single-node cluster)
+assert_min_row_count "SELECT from nodemetrics returns results" "k3d-k8sql-test-1" \
+    "SELECT name FROM nodemetrics" 1
+
+# Nodemetrics specific columns (timestamp, window, usage)
+assert_success "Nodemetrics has timestamp column" "k3d-k8sql-test-1" \
+    "SELECT name, timestamp FROM nodemetrics LIMIT 1"
+
+assert_success "Nodemetrics has window column" "k3d-k8sql-test-1" \
+    "SELECT name, window FROM nodemetrics LIMIT 1"
+
+assert_success "Nodemetrics has usage column" "k3d-k8sql-test-1" \
+    "SELECT name, usage FROM nodemetrics LIMIT 1"
+
+# All nodemetrics columns together
+assert_success "Nodemetrics all special columns" "k3d-k8sql-test-1" \
+    "SELECT name, timestamp, window, usage FROM nodemetrics"
+
+# Namespace filter on podmetrics
+assert_success "Podmetrics with namespace filter" "k3d-k8sql-test-1" \
+    "SELECT name FROM podmetrics WHERE namespace = 'kube-system'"
+
+# Verify core pods table still works (not overwritten by metrics pods)
+assert_contains "Core pods table still has spec column" "k3d-k8sql-test-1" \
+    "SELECT name, spec FROM pods WHERE namespace = 'kube-system' LIMIT 1" "containers"
+
+# Verify core nodes table still works (not overwritten by metrics nodes)
+assert_success "Core nodes table still has spec/status columns" "k3d-k8sql-test-1" \
+    "SELECT name, spec, status FROM nodes LIMIT 1"
+
+# JSON extraction from containers array
+assert_success "Extract container metrics from podmetrics" "k3d-k8sql-test-1" \
+    "SELECT name, json_get_str(containers, '[0].name') as container FROM podmetrics LIMIT 1"
+
+# JSON extraction from usage object
+assert_success "Extract CPU from nodemetrics usage" "k3d-k8sql-test-1" \
+    "SELECT name, json_get_str(usage, 'cpu') as cpu FROM nodemetrics LIMIT 1"
+
+print_summary


### PR DESCRIPTION
## Summary

- Add `k8s-metrics` crate for PodMetrics and NodeMetrics types (metrics.k8s.io/v1beta1)
- Register `podmetrics` and `nodemetrics` tables in core registry
- Use custom table names to avoid conflict with core `pods`/`nodes` tables
- Add integration test for metrics API (skips gracefully if metrics-server unavailable)

## Details

The metrics API types from `k8s-metrics` use `pods` and `nodes` as their plural names (for API calls), which would conflict with core Pod/Node resources. This fix:

1. Adds k8s-metrics v0.26 dependency (matches k8s-openapi version)
2. Manually constructs ResourceInfo with custom table names (`podmetrics`/`nodemetrics`) while preserving the correct API plural for K8s API calls
3. Adds appropriate schema columns (timestamp, window, containers/usage)

## Test plan

- [x] `SELECT * FROM pods` still works (core pods table unaffected)
- [x] `SELECT * FROM podmetrics` returns pod metrics with timestamp, window, containers
- [x] `SELECT * FROM nodemetrics` returns node metrics with timestamp, window, usage
- [x] `SHOW TABLES` shows all four tables: pods, nodes, podmetrics, nodemetrics
- [x] Integration test added (`tests/integration/tests/22-metrics-api.sh`)
- [x] `cargo clippy` passes
- [x] `cargo build --release` succeeds

**Note**: Integration test skips gracefully in CI (k3d clusters don't have metrics-server). Tests run when metrics-server is available (EKS, GKE, etc.).