### PR TITLE
refactor: use PostgreSqlDialect consistently for SQL parsing

### DIFF
--- a/src/datafusion_integration/hooks.rs
+++ b/src/datafusion_integration/hooks.rs
@@ -380,11 +380,11 @@ impl QueryHook for ShowDatabasesHook {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::sql::sqlparser::dialect::GenericDialect;
+    use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
     use datafusion::sql::sqlparser::parser::Parser;
 
     fn parse_statement(sql: &str) -> Statement {
-        let dialect = GenericDialect {};
+        let dialect = PostgreSqlDialect {};
         Parser::parse_sql(&dialect, sql).unwrap().pop().unwrap()
     }
 

--- a/src/datafusion_integration/json_path.rs
+++ b/src/datafusion_integration/json_path.rs
@@ -42,7 +42,7 @@
 //! ensuring JSON paths inside string literals are not converted.
 
 use crate::kubernetes::discovery::DEFAULT_JSON_OBJECT_COLUMNS;
-use datafusion::sql::sqlparser::dialect::GenericDialect;
+use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::sqlparser::tokenizer::{Token, Tokenizer};
 use std::collections::HashSet;
 
@@ -371,7 +371,7 @@ pub fn preprocess_json_paths(sql: &str, json_columns: Option<&HashSet<String>>) 
     let default_columns = build_json_columns_set(&[]);
     let json_columns = json_columns.unwrap_or(&default_columns);
 
-    let dialect = GenericDialect {};
+    let dialect = PostgreSqlDialect {};
     let mut tokenizer = Tokenizer::new(&dialect, sql);
 
     let tokens = match tokenizer.tokenize() {

--- a/src/datafusion_integration/preprocess.rs
+++ b/src/datafusion_integration/preprocess.rs
@@ -57,7 +57,7 @@
 use super::{json_path, prql};
 use anyhow::Result;
 use datafusion::sql::sqlparser::ast::Statement;
-use datafusion::sql::sqlparser::dialect::GenericDialect;
+use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
 use datafusion::sql::sqlparser::parser::Parser;
 use regex::Regex;
 use std::sync::LazyLock;
@@ -179,7 +179,7 @@ pub fn preprocess_sql(sql: &str) -> Result<String> {
 /// This function rejects any DDL (CREATE, DROP, ALTER) or DML (INSERT, UPDATE, DELETE)
 /// statements with a clear error message.
 pub fn validate_read_only(sql: &str) -> anyhow::Result<()> {
-    let dialect = GenericDialect {};
+    let dialect = PostgreSqlDialect {};
     let statements =
         Parser::parse_sql(&dialect, sql).map_err(|e| anyhow::anyhow!("SQL parse error: {}", e))?;
 
@@ -505,10 +505,10 @@ mod tests {
     #[test]
     fn test_parser_supports_chained_arrows() {
         // Test if DataFusion's SQL parser natively supports chained arrow operators
-        use datafusion::sql::sqlparser::dialect::GenericDialect;
+        use datafusion::sql::sqlparser::dialect::PostgreSqlDialect;
         use datafusion::sql::sqlparser::parser::Parser;
 
-        let dialect = GenericDialect {};
+        let dialect = PostgreSqlDialect {};
 
         // Test chained arrows WITHOUT preprocessing
         let sql = "SELECT spec->'selector'->>'app' FROM pods";


### PR DESCRIPTION
## Summary

- Switch from `GenericDialect` to `PostgreSqlDialect` in all sqlparser usages
- Ensures consistency with PRQL's PostgreSQL target dialect
- Aligns with k8sql's PostgreSQL wire protocol in daemon mode

## Why

k8sql presents as a PostgreSQL-compatible database:
- Daemon mode speaks PostgreSQL wire protocol (pgwire)
- PRQL compiles to PostgreSQL dialect SQL
- JSON operators use PostgreSQL's `->` and `->>`
- Regex uses PostgreSQL's `~` operator

Using `PostgreSqlDialect` throughout eliminates potential edge cases where PostgreSQL-specific SQL syntax might not parse correctly with `GenericDialect`.

## Changes

| File | Change |
|------|--------|
| `json_path.rs` | Tokenizer dialect |
| `preprocess.rs` | Parser dialect + tests |
| `hooks.rs` | Test dialect |